### PR TITLE
Update ave and wiper_interval parameters

### DIFF
--- a/RS03AXPS-SF03A-3A-FLORTD301.yaml
+++ b/RS03AXPS-SF03A-3A-FLORTD301.yaml
@@ -5,18 +5,19 @@
 # ------------------------------------------------------------------------------
 #    0-01   2016-05-16   djm     Default parameters query
 #    0-02   2016-05-19   djm     Added additional parameter information
+#    0-03   2016-05-23   dam     Update ave and wiper_interval parameters
 #
 
 parameters:
 
 ### Startup parameters ###
 
-  ave: 1                                   # Measurements per Reported Value ([1, 255] [1]) 
-  clk_interval: 00:00:00                   # Run Clock Sync Interval (None [00:00:00]) HH:MM:SS
+  ave: 18                                  # Measurements per Reported Value ([1, 255] [1]) 
   man: 0                                   # Manual Mode ({u'Disable': 0, u'Enable': 1} [0]) 
   pkt: 0                                   # Measurements per Packet ([0, 65535] [0]) 
   rec: 0                                   # Recording Mode ({u'Disable': 0, u'Enable': 1} [0]) 
   seq: 0                                   # Predefined Output Sequence ([0, 3] [0]) 
   set: 0                                   # Packets per Set ([0, 65535] [0]) 
-  status_interval: 00:00:00                # Acquire Status Interval (None [00:00:00]) HH:MM:SS
-  wiper_interval: 00:00:00                 # Run Wiper Interval (None [00:00:00]) HH:MM:SS
+  clk_interval: 00:00:00                   # Driver Parameter: Run Clock Sync Interval (None [00:00:00]) HH:MM:SS
+  status_interval: 00:00:00                # Driver Parameter: Acquire Status Interval (None [00:00:00]) HH:MM:SS
+  wiper_interval: 00:30:00                 # Driver Parameter: Run Wiper Interval (None [00:00:00]) HH:MM:SS


### PR DESCRIPTION
Dan - I've reviewed this file and made updates. Eventually, we will not want the wiper to run on an interval for profiling instruments. Rather, mission execution should command the "wipe" at opportune times. For the sake of the 24 hr deployed test, I've set the interval to 30min.

Dana
