### PR TITLE
twisted 17.0 causes dependecy error

### DIFF
--- a/anaconda_build/ooi-instrument-agent/meta.yaml
+++ b/anaconda_build/ooi-instrument-agent/meta.yaml
@@ -14,7 +14,7 @@ requirements:
     - gevent
     - pyzmq
     - python-consul
-    - twisted
+    - twisted ==16.6.0
   run:
     - python
     - setuptools
@@ -22,7 +22,7 @@ requirements:
     - gevent
     - pyzmq
     - python-consul
-    - twisted
+    - twisted ==16.6.0
 
 build:
   number: 0


### PR DESCRIPTION
restrict twisted to 16.6 to prevent error in 17.0 version where Automa dependency causes conda build failure